### PR TITLE
Setting worldCopyJump to true

### DIFF
--- a/app/components/map.hbs
+++ b/app/components/map.hbs
@@ -9,6 +9,7 @@
     @onMoveend={{this.setZoom}}
     @onZoomstart={{this.zoomStart}}
     @onZoomend={{this.zoomEnd}}
+    @worldCopyJump={{true}}
     {{did-insert this.fetchGlobalRecords @publishedDate}}
     {{did-update this.fetchGlobalRecords @publishedDate}}
     {{did-insert this.fetchCountyRecords @location @publishedDate}}


### PR DESCRIPTION
Enabling `worldCopyJump` so that the map tracks when you pan to another "copy" of the world


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
